### PR TITLE
Increase jobs delay

### DIFF
--- a/app/jobs/scheduled/update_cryptocurrencies.rb
+++ b/app/jobs/scheduled/update_cryptocurrencies.rb
@@ -3,7 +3,7 @@ module Jobs
 
   	include Sidekiq::Worker
 
-    every 5.minutes
+    every 10.minutes
 
     def execute(args)
 	     

--- a/app/jobs/scheduled/update_stocks.rb
+++ b/app/jobs/scheduled/update_stocks.rb
@@ -3,7 +3,7 @@ module Jobs
 
   	include Sidekiq::Worker
 
-    every 5.minutes
+    every 10.minutes
 
     def execute(args)
       


### PR DESCRIPTION
Increase jobs delay to 10 minutes to give enough room for other jobs to be performed.